### PR TITLE
Xulrunner 31 compat

### DIFF
--- a/application.ini
+++ b/application.ini
@@ -25,4 +25,4 @@ ID={f48601d0-39a1-11e0-a013-00241d8cf371}
 
 [Gecko]
 MinVersion=22.0
-MaxVersion=23.*
+MaxVersion=31.*

--- a/src/csChm.cpp
+++ b/src/csChm.cpp
@@ -86,7 +86,11 @@ NS_IMETHODIMP csChm::getAttribute(char **attr, char *m)
 }
 
 NS_IMPL_CLASSINFO(csChm, NULL, 0, CS_CHM_CID)
+#ifdef NS_IMPL_ISUPPORTS_CI
+NS_IMPL_ISUPPORTS_CI(csChm, csIChm)
+#else
 NS_IMPL_ISUPPORTS1_CI(csChm, csIChm)
+#endif
 
 /* long openChm (in nsILocalFile file); */
 NS_IMETHODIMP csChm::OpenChm(nsILocalFile *file, const char *folder, int32_t *_retval)


### PR DESCRIPTION
Xulrunner 31 introduced the variadic macro NS_IMPL_ISUPPURTS_CI replacing several macros which recieved a fixed number of arguments (along the lines of NS_IMPL_ISUPPURTS[n]_CI)
